### PR TITLE
Add optional commit argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,12 @@ inputs:
   style:
     description: "style passed to clang-format. reads .clang-format file in the repo by default. see clang-format docs for more."
     default: "file"
+  commit:
+    description: "commit passed to clang-format. From clang-format documentation: Revision from which to compute the diff."
+    default: "HEAD^"
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.style }}
+    - ${{ inputs.commit }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-git-clang-format --style="$1" HEAD^
+git-clang-format --style="$1" $2


### PR DESCRIPTION
This PR adds an optional `commit` option to be passed to `clang-format` in place of `HEAD^`.